### PR TITLE
[송민혁] 카테고리 버튼 string 대신 enum으로 타입 좁히기

### DIFF
--- a/src/components/Button/Category/CategoryButton.types.ts
+++ b/src/components/Button/Category/CategoryButton.types.ts
@@ -1,0 +1,5 @@
+export enum ButtonCategoryText {
+  'ALL' = '전체',
+  'TRADING' = '판매중',
+  'COLLECTION' = '컬렉션',
+}

--- a/src/components/Button/Category/CategoryButtonGroup.tsx
+++ b/src/components/Button/Category/CategoryButtonGroup.tsx
@@ -3,10 +3,15 @@
 import '@/styles/tailwind.css';
 import { useState } from 'react';
 import { Button } from '..';
+import { ButtonCategoryText } from './CategoryButton.types';
 
 function CategoryButtonGroup() {
   const [content, setContent] = useState('');
-  const labelTexts = ['전체', '판매중', '컬렉션'];
+  const labelTexts: ButtonCategoryText[] = [
+    ButtonCategoryText.ALL, // 전체
+    ButtonCategoryText.TRADING, // 판매중
+    ButtonCategoryText.COLLECTION, // 컬렉션
+  ];
 
   const handleActive = (buttonLabel: string) => {
     setContent(buttonLabel);


### PR DESCRIPTION
## 📖 작업 내용

- [x] 카테고리 버튼 타입 좁히기  (string -> enum) 

## ✅ PR 포인트

타입을 더 좁힘으로써 타입 시스템의 자동 완성을 더 활용할 수 있게 했습니다.

## 📸 스크린샷
<img width="279" alt="image" src="https://github.com/final-project-temporaryName/youth_frontend/assets/98685266/bdaa33f3-906d-4221-9b87-07c68c5ef156">


<img width="419" alt="image" src="https://github.com/final-project-temporaryName/youth_frontend/assets/98685266/ae7b6f18-0e08-4b78-ad73-07f7e38024fc">
