### PR TITLE
[송규경] 로그인 구현 및 css 원상복귀, swiper 이미지 개수 조정

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+  reactStrictMode: false,
   swcMinify: true,
   webpack: (config) => {
     config.module.rules.push({

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: false,
+  reactStrictMode: true,
   swcMinify: true,
   webpack: (config) => {
     config.module.rules.push({

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "axios": "^1.6.5",
         "classnames": "^2.5.1",
         "dotenv": "^16.3.2",
+        "lodash": "^4.17.21",
         "next": "14.1.0",
         "next-auth": "^4.24.5",
         "react": "^18",
@@ -31,6 +32,7 @@
       "devDependencies": {
         "@svgr/webpack": "^8.1.0",
         "@types/jsdom": "^21.1.6",
+        "@types/lodash": "^4.14.202",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -3367,6 +3369,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
       "dev": true
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "axios": "^1.6.5",
     "classnames": "^2.5.1",
     "dotenv": "^16.3.2",
+    "lodash": "^4.17.21",
     "next": "14.1.0",
     "next-auth": "^4.24.5",
     "react": "^18",
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",
     "@types/jsdom": "^21.1.6",
+    "@types/lodash": "^4.14.202",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/api/auth/getMe.ts
+++ b/src/api/auth/getMe.ts
@@ -1,0 +1,10 @@
+import instance from '../axios';
+
+export const getMe = async () => {
+  try {
+    const response = await instance.get('/users/me');
+    return response.data;
+  } catch (error: any) {
+    return error.response;
+  }
+};

--- a/src/api/auth/postSocialInfo.ts
+++ b/src/api/auth/postSocialInfo.ts
@@ -1,0 +1,13 @@
+import instance from '../axios';
+
+export const postUserId = async (id: string | undefined, type: string) => {
+  try {
+    const response = await instance.post('/login', {
+      socialId: id,
+      socialType: type,
+    });
+    return response.data;
+  } catch (error: any) {
+    return error.response;
+  }
+};

--- a/src/api/auth/postUserId.ts
+++ b/src/api/auth/postUserId.ts
@@ -1,3 +1,0 @@
-export const postUserId = (id: string | undefined) => {
-  // fetch로 구현 예정
-};

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -17,8 +17,8 @@ instance.interceptors.request.use(
         state: { userAccessToken, userRefreshToken },
       } = JSON.parse(userAuth);
 
-      config.headers.Authorization = `Bearer ${userAccessToken}`;
-      config.headers['Authorization-refresh'] = `Bearer ${userRefreshToken}`;
+      config.headers.Authorization = `${userAccessToken}`;
+      config.headers['Authorization-refresh'] = `${userRefreshToken}`;
 
       console.log('request start', config);
       return config;
@@ -56,7 +56,7 @@ instance.interceptors.response.use(
         newParsedUserAuth.state.userAccessToken = newAccessToken;
         window.localStorage.setItem('store', JSON.stringify(newParsedUserAuth));
 
-        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        originalRequest.headers.Authorization = `${newAccessToken}`;
 
         return axios(originalRequest);
       }

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -61,6 +61,9 @@ instance.interceptors.response.use(
         return axios(originalRequest);
       }
     }
+    if (status === 403) {
+      window.location.replace('/login');
+    }
 
     console.log('response error', error);
     return Promise.reject(error);

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import _ from 'lodash';
 
 const instance = axios.create({
   baseURL: 'http://youth-alb-1112492853.ap-northeast-2.elb.amazonaws.com',
@@ -22,6 +23,41 @@ instance.interceptors.request.use(
     }
   },
   (error) => {
+    return Promise.reject(error);
+  },
+);
+
+instance.interceptors.response.use(
+  (Response) => {
+    return Response;
+  },
+  async (error) => {
+    const {
+      config,
+      response: { status },
+    } = error;
+    if (status === 401) {
+      const originalRequest = config;
+      const userAuth = localStorage.getItem('store');
+
+      if (userAuth) {
+        const oldParsedUserAuth = JSON.parse(userAuth);
+        const newParsedUserAuth = _.cloneDeep(oldParsedUserAuth);
+        const { userAccessToken, userRefreshToken } = oldParsedUserAuth.state;
+        const { data } = await axios.post('/reissue', {
+          accessToken: userAccessToken,
+          refreshToken: userRefreshToken,
+        });
+        const { accessToken: newAccessToken } = data;
+        newParsedUserAuth.state.userAccessToken = newAccessToken;
+        localStorage.setItem('store', JSON.stringify(newParsedUserAuth));
+
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+
+        return axios(originalRequest);
+      }
+    }
+
     return Promise.reject(error);
   },
 );

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -4,4 +4,26 @@ const instance = axios.create({
   baseURL: 'http://youth-alb-1112492853.ap-northeast-2.elb.amazonaws.com',
 });
 
+instance.interceptors.request.use(
+  (config) => {
+    const userAuth = localStorage.getItem('store');
+
+    if (!userAuth) {
+      return config;
+    } else {
+      const {
+        state: { userAccessToken, userRefreshToken },
+      } = JSON.parse(userAuth);
+
+      config.headers.Authorization = `Bearer ${userAccessToken}`;
+      config.headers['Authorization-refresh'] = `Bearer ${userRefreshToken}`;
+
+      return config;
+    }
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);
+
 export default instance;

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -7,9 +7,10 @@ const instance = axios.create({
 
 instance.interceptors.request.use(
   (config) => {
-    const userAuth = localStorage.getItem('store');
+    const userAuth = window.localStorage.getItem('store');
 
     if (!userAuth) {
+      console.log('request start', config);
       return config;
     } else {
       const {
@@ -19,16 +20,19 @@ instance.interceptors.request.use(
       config.headers.Authorization = `Bearer ${userAccessToken}`;
       config.headers['Authorization-refresh'] = `Bearer ${userRefreshToken}`;
 
+      console.log('request start', config);
       return config;
     }
   },
   (error) => {
+    console.log('request error', error);
     return Promise.reject(error);
   },
 );
 
 instance.interceptors.response.use(
   (Response) => {
+    console.log('get response', Response);
     return Response;
   },
   async (error) => {
@@ -38,7 +42,7 @@ instance.interceptors.response.use(
     } = error;
     if (status === 401) {
       const originalRequest = config;
-      const userAuth = localStorage.getItem('store');
+      const userAuth = window.localStorage.getItem('store');
 
       if (userAuth) {
         const oldParsedUserAuth = JSON.parse(userAuth);
@@ -50,7 +54,7 @@ instance.interceptors.response.use(
         });
         const { accessToken: newAccessToken } = data;
         newParsedUserAuth.state.userAccessToken = newAccessToken;
-        localStorage.setItem('store', JSON.stringify(newParsedUserAuth));
+        window.localStorage.setItem('store', JSON.stringify(newParsedUserAuth));
 
         originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
 
@@ -58,6 +62,7 @@ instance.interceptors.response.use(
       }
     }
 
+    console.log('response error', error);
     return Promise.reject(error);
   },
 );

--- a/src/api/fetchRequestHandler.ts
+++ b/src/api/fetchRequestHandler.ts
@@ -1,47 +1,8 @@
-type AuthBasedRequestType = {
+type RequestType = {
   url: string;
-  token: string;
   method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
   params?: { [key: string]: any };
   body?: any;
-};
-
-type RequestType = Omit<AuthBasedRequestType, 'token'>;
-
-/** token based request handler
- * @param url request url
- * @param token auth token
- * @param method http method type
- * @param params request parameters
- * @param body request body
- */
-
-export const authBasedRequest = async <T>({ url, token, method = 'GET', params, body }: AuthBasedRequestType) => {
-  const baseURL = 'http://youth-alb-1112492853.ap-northeast-2.elb.amazonaws.com/';
-  const queryString = new URLSearchParams(params).toString();
-
-  const fullUrl = queryString ? `${baseURL}${url}?${queryString}` : `${baseURL}${url}`;
-
-  const options: RequestInit = {
-    method,
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  };
-
-  // Only include body if it exists and if the method is not GET
-  if (body && method !== 'GET') {
-    options.body = JSON.stringify(body);
-  }
-
-  const response = await fetch(fullUrl, options);
-
-  if (!response.ok) {
-    // 가장 가까운 Error Boundary의 error.tsx를 활성화 시킴
-    throw new Error('error occurred');
-  }
-
-  return (await response.json()) as T;
 };
 
 /** request handler

--- a/src/api/users/getMyPage.ts
+++ b/src/api/users/getMyPage.ts
@@ -1,0 +1,10 @@
+import instance from '../axios';
+
+export const getMyPage = async () => {
+  try {
+    const response = await instance.get('/users/mypage');
+    return response.data;
+  } catch (error: any) {
+    return error.response;
+  }
+};

--- a/src/app/(root-modal)/ArtModal/ArtModal.tsx
+++ b/src/app/(root-modal)/ArtModal/ArtModal.tsx
@@ -15,8 +15,6 @@ export default function ArtModal() {
 
   const clickedArtworkId = useStore((state) => state.clickedArtworkId);
 
-  console.log(clickedArtworkId);
-
   const imageUrlList = [
     'https://images.unsplash.com/photo-1579273166152-d725a4e2b755?q=80&w=1301&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
     'https://images.unsplash.com/photo-1707305318944-0dd559c12789?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',

--- a/src/app/(unauth)/login/_components/KakaoLoginButton.tsx
+++ b/src/app/(unauth)/login/_components/KakaoLoginButton.tsx
@@ -1,15 +1,22 @@
 'use client';
 
-import { signIn, useSession } from 'next-auth/react';
+import { signIn, signOut, useSession } from 'next-auth/react';
 import Image from 'next/image';
 import { MouseEvent } from 'react';
 import kakaoLogoImg from '../../../../../public/assets/images/kakaoLogo.png';
 
 function KakaoLoginButton() {
+  const { data: session } = useSession();
+
   const handleKakaoLoginClick = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
 
-    await signIn('kakao', { redirect: true, callbackUrl: '/login/postFlow' });
+    if (session) {
+      // 추후 로그아웃 기능 삭제 예정
+      await signOut();
+    } else {
+      await signIn('kakao', { redirect: true, callbackUrl: '/login/postFlow' });
+    }
   };
 
   return (

--- a/src/app/(unauth)/login/_components/NaverLoginButton.tsx
+++ b/src/app/(unauth)/login/_components/NaverLoginButton.tsx
@@ -4,9 +4,11 @@ import { signIn, signOut, useSession } from 'next-auth/react';
 import Image from 'next/image';
 import { MouseEvent } from 'react';
 import naverLogoImg from '../../../../../public/assets/images/naverLogo.png';
+import useIfLogin from '@/hooks/useIfLogin';
 
 function NaverLoginButton() {
   const { data: session } = useSession();
+  const { result } = useIfLogin();
 
   const handleNaverLoginClick = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
@@ -20,6 +22,7 @@ function NaverLoginButton() {
   };
 
   console.log(session);
+  console.log(result);
 
   return (
     <button

--- a/src/app/(unauth)/login/_components/NaverLoginButton.tsx
+++ b/src/app/(unauth)/login/_components/NaverLoginButton.tsx
@@ -8,7 +8,7 @@ import useIfLogin from '@/hooks/useIfLogin';
 
 function NaverLoginButton() {
   const { data: session } = useSession();
-  const { result } = useIfLogin();
+  const { userData } = useIfLogin();
 
   const handleNaverLoginClick = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
@@ -22,7 +22,7 @@ function NaverLoginButton() {
   };
 
   console.log(session);
-  console.log(result);
+  console.log(userData);
 
   return (
     <button

--- a/src/app/(unauth)/login/_components/RedirectToHome.tsx
+++ b/src/app/(unauth)/login/_components/RedirectToHome.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-// import { postUserId } from '@/api/auth/postUserId';
+import { postUserId } from '@/api/auth/postSocialInfo';
+import { useStore } from '@/store';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
@@ -9,16 +10,29 @@ export default async function RedirectToHome() {
   const router = useRouter();
   const { data: session } = useSession();
 
-  const handleUserId = () => {
-    // userRole zustand 저장
+  const { setUserAccessToken, setUserRefreshToken } = useStore((state) => ({
+    setUserAccessToken: state.setUserAccessToken,
+    setUserRefreshToken: state.setUserRefreshToken,
+  }));
+
+  const socialId = session?.user.id;
+  const socialType = socialId?.length === 10 ? 'KAKAO' : 'NAVER';
+
+  const handleUserId = async () => {
+    try {
+      const { accessToken, refreshToken } = await postUserId(socialId, socialType);
+      setUserAccessToken(accessToken);
+      setUserRefreshToken(refreshToken);
+    } finally {
+      router.replace('/');
+    }
   };
 
   useEffect(() => {
-    // handleUserId();
-
-    router.replace('/');
-
+    if (session) {
+      handleUserId();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [session]);
   return null;
 }

--- a/src/app/(unauth)/login/_components/RedirectToHome.tsx
+++ b/src/app/(unauth)/login/_components/RedirectToHome.tsx
@@ -3,6 +3,7 @@
 import { postUserId } from '@/api/auth/postSocialInfo';
 import { useStore } from '@/store';
 import { useSession } from 'next-auth/react';
+import { LocaleRouteNormalizer } from 'next/dist/server/future/normalizers/locale-route-normalizer';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
@@ -10,9 +11,10 @@ export default async function RedirectToHome() {
   const router = useRouter();
   const { data: session } = useSession();
 
-  const { setUserAccessToken, setUserRefreshToken } = useStore((state) => ({
+  const { setUserAccessToken, setUserRefreshToken, setUserRole } = useStore((state) => ({
     setUserAccessToken: state.setUserAccessToken,
     setUserRefreshToken: state.setUserRefreshToken,
+    setUserRole: state.setUserRole,
   }));
 
   const socialId = session?.user.id;
@@ -20,13 +22,16 @@ export default async function RedirectToHome() {
 
   const handleUserId = async () => {
     try {
-      const { accessToken, refreshToken } = await postUserId(socialId, socialType);
+      const { accessToken, refreshToken, userRole } = await postUserId(socialId, socialType);
       setUserAccessToken(accessToken);
       setUserRefreshToken(refreshToken);
+      setUserRole(userRole);
     } finally {
       router.replace('/');
     }
   };
+
+  console.log(localStorage.getItem('store'));
 
   useEffect(() => {
     if (session) {

--- a/src/app/(unauth)/login/_components/RedirectToHome.tsx
+++ b/src/app/(unauth)/login/_components/RedirectToHome.tsx
@@ -3,7 +3,6 @@
 import { postUserId } from '@/api/auth/postSocialInfo';
 import { useStore } from '@/store';
 import { useSession } from 'next-auth/react';
-import { LocaleRouteNormalizer } from 'next/dist/server/future/normalizers/locale-route-normalizer';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
@@ -31,12 +30,11 @@ export default async function RedirectToHome() {
     }
   };
 
-  console.log(localStorage.getItem('store'));
-
   useEffect(() => {
     if (session) {
       handleUserId();
     }
+    console.log(localStorage.getItem('store'));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [session]);
   return null;

--- a/src/app/(unauth)/login/_components/RedirectToHome.tsx
+++ b/src/app/(unauth)/login/_components/RedirectToHome.tsx
@@ -10,10 +10,12 @@ export default async function RedirectToHome() {
   const router = useRouter();
   const { data: session } = useSession();
 
-  const { setUserAccessToken, setUserRefreshToken, setUserRole } = useStore((state) => ({
+  const { setUserAccessToken, setUserRefreshToken, setUserRole, setLogin, setLogout } = useStore((state) => ({
     setUserAccessToken: state.setUserAccessToken,
     setUserRefreshToken: state.setUserRefreshToken,
     setUserRole: state.setUserRole,
+    setLogin: state.setLogin,
+    setLogout: state.setLogout,
   }));
 
   const socialId = session?.user.id;
@@ -25,11 +27,16 @@ export default async function RedirectToHome() {
       setUserAccessToken(accessToken);
       setUserRefreshToken(refreshToken);
       setUserRole(userRole);
+    } catch (error) {
+      console.error(error);
+      setLogout();
     } finally {
+      setLogin();
       router.replace('/');
     }
   };
 
+  // 이부분 때문에 strictMode 해제
   useEffect(() => {
     if (session) {
       handleUserId();

--- a/src/app/(unauth)/login/_components/RedirectToHome.tsx
+++ b/src/app/(unauth)/login/_components/RedirectToHome.tsx
@@ -4,9 +4,9 @@ import { postUserId } from '@/api/auth/postSocialInfo';
 import { useStore } from '@/store';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 
-export default async function RedirectToHome() {
+export default function RedirectToHome() {
   const router = useRouter();
   const { data: session } = useSession();
 
@@ -21,7 +21,9 @@ export default async function RedirectToHome() {
   const socialId = session?.user.id;
   const socialType = socialId?.length === 10 ? 'KAKAO' : 'NAVER';
 
-  const handleUserId = async () => {
+  const handleUserId = useCallback(async () => {
+    if (!session) return;
+
     try {
       const { accessToken, refreshToken, userRole } = await postUserId(socialId, socialType);
       setUserAccessToken(accessToken);
@@ -34,15 +36,14 @@ export default async function RedirectToHome() {
       setLogin();
       router.replace('/');
     }
-  };
+  }, [socialId, socialType]);
 
   // 이부분 때문에 strictMode 해제
   useEffect(() => {
-    if (session) {
-      handleUserId();
-    }
+    handleUserId();
+
     console.log(localStorage.getItem('store'));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [session]);
+  }, [handleUserId]);
   return null;
 }

--- a/src/components/Comment/CommentContainer.tsx
+++ b/src/components/Comment/CommentContainer.tsx
@@ -94,8 +94,6 @@ function CommentContainer({ likeCount, commentCount, artworkStatus }: CommentCon
     // data.comment를 첨부해서 post api 요청 로직 필요
   };
 
-  console.log(isCommentClicked);
-
   return (
     <div className="relative">
       <div className="absolute right-20" style={{ top: '-10px', zIndex: '2' }}>

--- a/src/components/NavBar/ProfileImgDropDown.tsx
+++ b/src/components/NavBar/ProfileImgDropDown.tsx
@@ -63,7 +63,6 @@ function ProfileImgDropDown({ userName, profileImg, major }: ProfileImgDropDownP
               </Button>
             </div>
             <div className="flex h-100 w-full flex-col border-t-1 border-solid border-t-gray-4">
-              {/* 추후 Link 변경 예정 */}
               <Link href={'/editProfile'}>
                 <div className="flex h-50 items-center px-18 hover:bg-gray-1">계정관리</div>
               </Link>

--- a/src/components/NavBar/ProfileImgDropDown.tsx
+++ b/src/components/NavBar/ProfileImgDropDown.tsx
@@ -64,7 +64,7 @@ function ProfileImgDropDown({ userName, profileImg, major }: ProfileImgDropDownP
             </div>
             <div className="flex h-100 w-full flex-col border-t-1 border-solid border-t-gray-4">
               {/* 추후 Link 변경 예정 */}
-              <Link href={'/'}>
+              <Link href={'/editProfile'}>
                 <div className="flex h-50 items-center px-18 hover:bg-gray-1">계정관리</div>
               </Link>
               {/* 추후 Link 변경 예정 */}

--- a/src/components/SlideContainer/SlideContainer.tsx
+++ b/src/components/SlideContainer/SlideContainer.tsx
@@ -2,7 +2,7 @@
 
 import '@/styles/tailwind.css';
 import Image from 'next/image';
-import { useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import SwiperCore from 'swiper';
 import 'swiper/css';
 import 'swiper/css/navigation';
@@ -24,10 +24,17 @@ function SlideContainer({ imageUrlList }: SlideContainerProps) {
   const swiperRef = useRef<SwiperCore>();
   const { width: browserWidthSize } = useBrowserSize();
 
+  const setSlidesPerView = (width: number | undefined) => {
+    if (!width) return 1;
+    if (width < 768) return 1;
+    else if (width < 1200) return 2;
+    else return 3;
+  };
+
   let slidesPerView;
-  if (browserWidthSize) {
-    slidesPerView = browserWidthSize > 1200 ? 3 : browserWidthSize > 767 ? 2 : 1;
-  }
+  slidesPerView = useMemo(() => setSlidesPerView(browserWidthSize), [browserWidthSize]);
+
+  console.log(browserWidthSize);
 
   const openModal = (imageUrl: string) => {
     setSelectedImage(imageUrl);

--- a/src/components/SlideContainer/SlideContainer.tsx
+++ b/src/components/SlideContainer/SlideContainer.tsx
@@ -44,8 +44,6 @@ function SlideContainer({ imageUrlList }: SlideContainerProps) {
   let slidesPerView;
   slidesPerView = useMemo(() => setSlidesPerView(browserWidthSize, imageUrlList.length), [browserWidthSize]);
 
-  console.log(browserWidthSize);
-
   const openModal = (imageUrl: string) => {
     setSelectedImage(imageUrl);
     setShowModal(true);

--- a/src/components/SlideContainer/SlideContainer.tsx
+++ b/src/components/SlideContainer/SlideContainer.tsx
@@ -11,15 +11,23 @@ import 'swiper/css/scrollbar';
 import { Navigation, Scrollbar } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import Expand from './Expand';
+import { useBrowserSize } from '@/hooks/useBrowserSize';
 
 interface SlideContainerProps {
   imageUrlList: string[];
 }
 
 function SlideContainer({ imageUrlList }: SlideContainerProps) {
-  const swiperRef = useRef<SwiperCore>();
   const [showModal, setShowModal] = useState(false);
   const [selectedImage, setSelectedImage] = useState('');
+
+  const swiperRef = useRef<SwiperCore>();
+  const { width: browserWidthSize } = useBrowserSize();
+
+  let slidesPerView;
+  if (browserWidthSize) {
+    slidesPerView = browserWidthSize > 1200 ? 3 : browserWidthSize > 767 ? 2 : 1;
+  }
 
   const openModal = (imageUrl: string) => {
     setSelectedImage(imageUrl);
@@ -39,7 +47,7 @@ function SlideContainer({ imageUrlList }: SlideContainerProps) {
         }}
         modules={[Navigation, Scrollbar]}
         spaceBetween={10}
-        slidesPerView={3}
+        slidesPerView={slidesPerView}
         autoplay={false}
         loop={false}
         navigation

--- a/src/components/SlideContainer/SlideContainer.tsx
+++ b/src/components/SlideContainer/SlideContainer.tsx
@@ -24,15 +24,25 @@ function SlideContainer({ imageUrlList }: SlideContainerProps) {
   const swiperRef = useRef<SwiperCore>();
   const { width: browserWidthSize } = useBrowserSize();
 
-  const setSlidesPerView = (width: number | undefined) => {
+  const setSlidesPerView = (width: number | undefined, num: number) => {
     if (!width) return 1;
-    if (width < 768) return 1;
-    else if (width < 1200) return 2;
-    else return 3;
+
+    if (num > 3) {
+      if (width < 768) return 1;
+      else if (width < 1200) return 2;
+      else return 3;
+    } else {
+      if (num === 2) {
+        if (width < 768) return 1;
+        else return 2;
+      } else if (num === 1) {
+        return 1;
+      }
+    }
   };
 
   let slidesPerView;
-  slidesPerView = useMemo(() => setSlidesPerView(browserWidthSize), [browserWidthSize]);
+  slidesPerView = useMemo(() => setSlidesPerView(browserWidthSize, imageUrlList.length), [browserWidthSize]);
 
   console.log(browserWidthSize);
 

--- a/src/hooks/useBrowserSize.ts
+++ b/src/hooks/useBrowserSize.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+
+export const useBrowserSize = () => {
+  // 초기 state 값은 undefined로 세팅한다.
+  const [windowSize, setWindowSize] = useState<{
+    width: undefined | number;
+    height: undefined | number;
+  }>({
+    width: undefined,
+    height: undefined,
+  });
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const handleResize = () => {
+        setWindowSize({
+          // 현재 브라우저의 가로, 세로 길이로 셋팅
+          width: window.innerWidth,
+          height: window.innerHeight,
+        });
+      };
+
+      // resize 이벤트가 발생할 때 handleResize 함수가 실행되도록 한다.
+      window.addEventListener('resize', handleResize);
+
+      // 초기값을 설정할 수 있도록 handleResize 함수를 한 번 실행시킨다.
+      handleResize();
+
+      // 이벤트 리스너를 제거하여 이벤트 리스너가 리사이즈될 때마다 계속해서 생겨나지 않도록 처리한다. (clean up)
+      return () => window.removeEventListener('resize', handleResize);
+    } else {
+      return () =>
+        window.removeEventListener('resize', () => {
+          return null;
+        });
+    }
+  }, []); // 컴포넌트가 처음 마운트 될때와 언마운트 될 때 실행
+
+  return windowSize;
+};

--- a/src/hooks/useIfLogin.ts
+++ b/src/hooks/useIfLogin.ts
@@ -2,9 +2,9 @@ import { getMe } from '@/api/auth/getMe';
 import { useQuery } from '@tanstack/react-query';
 
 function useIfLogin() {
-  const result = useQuery({ queryKey: ['getMe'], queryFn: getMe });
+  const { data: userData } = useQuery({ queryKey: ['getMe'], queryFn: getMe });
 
-  return { result };
+  return { userData };
 }
 
 export default useIfLogin;

--- a/src/hooks/useIfLogin.ts
+++ b/src/hooks/useIfLogin.ts
@@ -1,0 +1,10 @@
+import { getMe } from '@/api/auth/getMe';
+import { useQuery } from '@tanstack/react-query';
+
+function useIfLogin() {
+  const result = useQuery({ queryKey: ['getMe'], queryFn: getMe });
+
+  return { result };
+}
+
+export default useIfLogin;

--- a/src/store/authSlice.ts
+++ b/src/store/authSlice.ts
@@ -5,4 +5,12 @@ export const createAuthSlice: StateCreator<AuthState> = (set) => ({
   isLogin: false,
   setLogin: () => set((state) => ({ ...state, isLogin: true })),
   setLogout: () => set((state) => ({ ...state, isLogin: false })),
+  userRole: '',
+  setUserRole: (data) => set((state) => ({ ...state, userRole: data })),
+  userId: 0,
+  setUserId: (data) => set((state) => ({ ...state, userId: data })),
+  userAccessToken: '',
+  setUserAccessToken: (data) => set((state) => ({ ...state, userAccessToken: data })),
+  userRefreshToken: '',
+  setUserRefreshToken: (data) => set((state) => ({ ...state, userRefreshToken: data })),
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,13 +1,29 @@
-import { createArtworkSlice } from './artworkSlice';
 import { create } from 'zustand';
+import { devtools, persist } from 'zustand/middleware';
+import { createArtworkSlice } from './artworkSlice';
 import { createAuthSlice } from './authSlice';
 import { createSearchSlice } from './searchSlice';
 import { ArtworkState, AuthState, SearchState } from './zustand.types';
 
 type SliceType = SearchState & AuthState & ArtworkState;
 
-export const useStore = create<SliceType>()((...a) => ({
-  ...createSearchSlice(...a),
-  ...createAuthSlice(...a),
-  ...createArtworkSlice(...a),
-}));
+export const useStore = create<SliceType>()(
+  devtools(
+    persist(
+      (...a) => ({
+        ...createSearchSlice(...a),
+        ...createAuthSlice(...a),
+        ...createArtworkSlice(...a),
+      }),
+      {
+        name: 'store',
+        partialize: (state) => ({
+          userRole: state.userRole,
+          userId: state.userId,
+          userAccessToken: state.userAccessToken,
+          userRefreshToken: state.userRefreshToken,
+        }),
+      },
+    ),
+  ),
+);

--- a/src/store/zustand.types.ts
+++ b/src/store/zustand.types.ts
@@ -8,6 +8,14 @@ export interface AuthState {
   isLogin: boolean;
   setLogin: () => void;
   setLogout: () => void;
+  userRole: string;
+  setUserRole: (data: string) => void;
+  userId: number;
+  setUserId: (data: number) => void;
+  userAccessToken: string;
+  setUserAccessToken: (data: string) => void;
+  userRefreshToken: string;
+  setUserRefreshToken: (data: string) => void;
 }
 
 export interface ArtworkState {

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -2,11 +2,11 @@
 
 /* Navbar component */
 .navBar {
-  @apply fixed left-0 top-0 flex h-80 w-full items-center justify-between gap-40 bg-gray-1 px-44 py-20 backdrop-blur-md;
+  @apply left-0 top-0 z-second flex h-80 w-full items-center justify-between gap-40 bg-white px-44 py-20 backdrop-blur-lg;
 }
 
 .navSearchBar {
-  @apply flex h-40 flex-shrink flex-grow items-center gap-10 rounded-lg bg-white px-32 py-8;
+  @apply flex h-40 max-w-600 flex-grow items-center gap-10 rounded-lg bg-gray-1 px-32 py-8;
 }
 
 /* LoginModal */


### PR DESCRIPTION
## 📖 작업 내용

- 브라우저 가로 길이 인식 커스텀 훅 사용하여 Swiper의 slidesPerView 개수 변경 구현
  - 데이터 개수가 1개나 2개 일 때의 개수도 조정
- sns 로그인 후, socialId, socialType 보내고 응답으로 온 것들 zustand persist로 localStorage에 저장
- axios interceptors로 401, 403 코드 응답에 대한 것 구현
- 개발용 계정 삭제로 인한 에러 해결
- css 쪽 스타일 원상 복귀
- fetch 핸들러 수정: 서버 컴포넌트의 fetch는 토큰이 필요없는 요청에만 써야할 것 같습니다
  - 토큰을 넣는 행위 자체가 클라이언트 컴포넌트의 동작 필요

## ✅ PR 포인트


## 📸 스크린샷
- 1200px 이상
![image](https://github.com/ArtTalkTalk/ArtTalkTalk_frontend/assets/122101706/ebe8ff06-94d9-4ee8-86c6-c91902e87080)

-1200px 이하
![image](https://github.com/ArtTalkTalk/ArtTalkTalk_frontend/assets/122101706/bcbc6db8-3453-4907-b22b-3b2abe5438f7)

- 767px 이하
![image](https://github.com/ArtTalkTalk/ArtTalkTalk_frontend/assets/122101706/0a3a040e-6969-4344-a4fc-772082b865d3)

