### PR TITLE
[김윤후] CardContainer 컴포넌트 리팩토링

### DIFF
--- a/src/app/(auth)/_component/MyPage/MainContainer.tsx
+++ b/src/app/(auth)/_component/MyPage/MainContainer.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { getArtworks } from '@/api/artworks/getArtworks';
 import CategoryButtonGroup from '@/components/Button/Category/CategoryButtonGroup';
 import CardContainer from '@/components/Card/CardContainer';
 import { usePathname } from 'next/navigation';
@@ -13,7 +14,7 @@ function MainContainer() {
   return (
     <main className={`ml-330 ${pathname === '/mypage' ? 'mt-157' : 'mt-77'}`}>
       <CategoryButtonGroup setMyPageValue={setLabel} />
-      <CardContainer type="mypage" />
+      <CardContainer type="mypage" queryKey={['allArtworks']} queryFn={getArtworks} />
     </main>
   );
 }

--- a/src/app/(unauth)/_components/Artist/ArtistCardSection.tsx
+++ b/src/app/(unauth)/_components/Artist/ArtistCardSection.tsx
@@ -4,6 +4,7 @@ import CardContainer from '@/components/Card/CardContainer';
 import { usePathname } from 'next/navigation';
 import { useState } from 'react';
 import ArtistLabelsGroup from './ArtistLabelsGroup';
+import { getArtworks } from '@/api/artworks/getArtworks';
 
 function ArtistCardSection() {
   const [label, setLabel] = useState<'전체' | '판매중'>('전체');
@@ -15,7 +16,7 @@ function ArtistCardSection() {
   return (
     <main className={`ml-330 ${firstPathname === 'artist' ? 'mt-157' : 'mt-77'}`}>
       <ArtistLabelsGroup setArtistValue={setLabel} />
-      <CardContainer type="artist" />
+      <CardContainer type="artist" queryKey={['allArtworks']} queryFn={getArtworks} />
     </main>
   );
 }

--- a/src/app/(unauth)/_components/Main/MainCardSection.tsx
+++ b/src/app/(unauth)/_components/Main/MainCardSection.tsx
@@ -3,6 +3,7 @@
 import CardContainer from '@/components/Card/CardContainer';
 import { useState } from 'react';
 import MainLabelsGroup from './MainLabelsGroup';
+import { getArtworks } from '@/api/artworks/getArtworks';
 
 function MainCardSection() {
   const [label, setLabel] = useState<'전체' | 'following'>('전체');
@@ -10,7 +11,7 @@ function MainCardSection() {
   return (
     <div className="flex-col-center relative mt-25">
       <MainLabelsGroup setMainValue={setLabel} />
-      <CardContainer type="main" />
+      <CardContainer type="main" queryKey={['allArtworks']} queryFn={getArtworks} />
     </div>
   );
 }

--- a/src/components/Card/CardContainer.tsx
+++ b/src/components/Card/CardContainer.tsx
@@ -7,17 +7,23 @@ import { useObserver } from '@/hooks/useObserver';
 import { useRef } from 'react';
 import { CardType } from '@/types/cards';
 
-interface Props {
-  type: 'main' | 'mypage' | 'artist';
+interface queryFnProps {
+  pageParam?: number | null;
 }
 
-export interface ArtWorks {
+interface CardContainerProps {
+  type: 'main' | 'mypage' | 'artist';
+  queryKey?: string[];
+  queryFn?: (props: queryFnProps) => Promise<any>;
+}
+
+interface ArtWorks {
   contents: CardType[];
   hasNext: boolean;
   pages: ArtWorks[];
 }
 
-function CardContainer({ type }: Props) {
+function CardContainer({ type }: CardContainerProps) {
   const { data, status, hasNextPage, fetchNextPage, isFetchingNextPage, isFetching } = useInfiniteQuery<
     ArtWorks,
     Error,

--- a/src/components/Card/CardContainer.tsx
+++ b/src/components/Card/CardContainer.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Card from './Card';
-import { getArtworks } from '@/api/artworks/getArtworks';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useObserver } from '@/hooks/useObserver';
 import { useRef } from 'react';
@@ -13,8 +12,8 @@ interface queryFnProps {
 
 interface CardContainerProps {
   type: 'main' | 'mypage' | 'artist';
-  queryKey?: string[];
-  queryFn?: (props: queryFnProps) => Promise<any>;
+  queryKey: string[];
+  queryFn: (props: queryFnProps) => Promise<any>;
 }
 
 interface ArtWorks {
@@ -23,7 +22,7 @@ interface ArtWorks {
   pages: ArtWorks[];
 }
 
-function CardContainer({ type }: CardContainerProps) {
+function CardContainer({ type, queryKey, queryFn }: CardContainerProps) {
   const { data, status, hasNextPage, fetchNextPage, isFetchingNextPage, isFetching } = useInfiniteQuery<
     ArtWorks,
     Error,
@@ -31,9 +30,9 @@ function CardContainer({ type }: CardContainerProps) {
     string[],
     number | null
   >({
-    queryKey: ['allArtworks'],
+    queryKey: queryKey,
     queryFn: async ({ pageParam }) => {
-      return await getArtworks({ pageParam });
+      return await queryFn({ pageParam });
     },
     getNextPageParam: (lastPage) => {
       return lastPage.hasNext ? lastPage.contents[lastPage.contents.length - 1].artworkId : undefined;


### PR DESCRIPTION
## 📖 작업 내용

- [x] 카드 데이터를 사용하는 모든 페이지에서 재사용할 수 있도록 CardContainer를 리팩토링

## ✅ PR 포인트
CardContainer의 props로 queryKey와 queryFn을 추가하였습니다.
CardContainer를 사용하는 각각의 다른 페이지에서 각각 다른 적절한 queryKey와 queryFn(api 호출 함수)을 넣어서 사용하시면 됩니다.


