### PR TITLE
[송규경] 핫픽스: 로그아웃 시 로컬스토리지 store key 삭제 안되는 오류 수정 및 배포 사이트 관련 핫픽스

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -65,7 +65,7 @@ instance.interceptors.response.use(
     if (status === 400) {
       if (error.response.data.message === 'JWT 토큰이 없습니다.') {
         window.alert('접근 권한이 없습니다. 로그인을 해주세요.');
-        window.location.replace('/');
+        window.location.replace('/login');
       }
     }
 

--- a/src/components/NavBar/NavigatorBox.tsx
+++ b/src/components/NavBar/NavigatorBox.tsx
@@ -20,7 +20,7 @@ function NavigatorBox() {
   const { data, isPending, isSuccess } = useQuery<GetMyPageResponseType>({
     queryKey: ['myPageInfo'],
     queryFn: getMyPage,
-    enabled: isLogin,
+    enabled: !!isLogin,
     staleTime: 3 * 1000,
   });
   const userInfo = data?.userProfileResponse as UserType;

--- a/src/components/NavBar/ProfileImgDropDown.tsx
+++ b/src/components/NavBar/ProfileImgDropDown.tsx
@@ -36,9 +36,9 @@ function ProfileImgDropDown({ userName, profileImg, major, isPending }: ProfileI
   };
 
   const handleLogoutClick = async () => {
-    removeStore();
     setLogout();
     await signOut();
+    removeStore();
     router.push('/');
   };
 

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -13,7 +13,6 @@ import { useParams } from 'next/navigation';
 import defaultProfileImg from '../../../public/assets/images/logo.png';
 import ProfileFallbackUI from '../FallbackUI/SideBar/ProfileFallbackUI';
 import AddLinkIcon from './AddLinkIcon';
-import EditIcon from './EditIcon';
 import LinkIcon from './LinkIcon';
 
 interface SideBarProps {
@@ -29,7 +28,7 @@ function SideBar({ displayStatus }: SideBarProps) {
     const { data, isPending } = useQuery({
       queryKey: ['myPageInfo'],
       queryFn: getMyPage,
-      enabled: isLogin,
+      enabled: !!isLogin,
       staleTime: 3 * 1000,
     });
     if (isPending) {


### PR DESCRIPTION
## 📖 작업 내용

- 로그아웃 시 로컬스토리지 store key 삭제 안되는 오류 수정
  - 코드 순서에 따라 로컬스토리지 key가 삭제 안되는 오류 해결
- 배포 사이트에서 권한 없음 alert 가 무한 루프로 뜨는 현상 때문에 핫픽스 (로컬에서는 이러지 않는데 Navbar의 enabled가 안먹히는 것 같음)

## ✅ PR 포인트


## 📸 스크린샷
