### PR TITLE
[송규경] 작품 상세 모달에서 작품 수정 및 삭제 구현, 용량 큰 파일의 경우 경고 모달 띄우기 등 여러가지 구현

### DIFF
--- a/public/assets/icons/menu.svg
+++ b/public/assets/icons/menu.svg
@@ -1,0 +1,5 @@
+<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12.2441" cy="7.27258" r="1" fill="gray"/>
+<circle cx="12.2441" cy="12.5023" r="1" fill="gray"/>
+<circle cx="12.2441" cy="17.7321" r="1" fill="gray"/>
+</svg>

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -45,7 +45,7 @@ instance.interceptors.response.use(
         const oldParsedUserAuth = JSON.parse(userAuth);
         const newParsedUserAuth = _.cloneDeep(oldParsedUserAuth);
         const { userAccessToken, userRefreshToken } = oldParsedUserAuth.state;
-        const { data } = await axios.post('/reissue', {
+        const { data } = await instance.post('/reissue', {
           accessToken: userAccessToken,
           refreshToken: userRefreshToken,
         });
@@ -59,13 +59,18 @@ instance.interceptors.response.use(
       }
     }
     if (status === 403) {
-      window.alert('로그인이 만료되었습니다.');
-      window.location.replace('/login');
+      window.sessionStorage.setItem('errorMessage', error.response.data.message as string);
+      window.localStorage.removeItem('store');
+      window.location.replace('/NoAccess');
     }
     if (status === 400) {
-      if (error.response.data.message === 'JWT 토큰이 없습니다.') {
-        window.alert('접근 권한이 없습니다. 로그인을 해주세요.');
-        window.location.replace('/login');
+      if (
+        error.response.data.message === 'JWT 토큰이 없습니다.' ||
+        error.response.data.message === '만료된 JWT 토큰입니다.'
+      ) {
+        window.sessionStorage.setItem('errorMessage', error.response.data.message as string);
+        window.localStorage.removeItem('store');
+        window.location.replace('/NoAccess');
       }
     }
 

--- a/src/app/(auth)/myAccount/layout.tsx
+++ b/src/app/(auth)/myAccount/layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import CheckLogin from '@/components/CheckLogin';
 import Tab from '@/components/Tab/Tab';
 import { ReactNode, useState } from 'react';
 
@@ -13,6 +14,7 @@ export default function Layout({ editProfile, deleteProfile }: LayoutProps) {
 
   return (
     <div className="flex flex-row">
+      <CheckLogin />
       <Tab activeTab={activeTab} setActiveTab={setActiveTab} />
       {activeTab === 'profile' ? editProfile : deleteProfile}
     </div>

--- a/src/app/(no-access)/NoAccess/page.tsx
+++ b/src/app/(no-access)/NoAccess/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import InfiniteText from '@/components/InfiniteText';
+import Image from 'next/image';
+import Link from 'next/link';
+import logoImg from '../../../../public/assets/images/logo.png';
+
+function NoAccess() {
+  return (
+    <div className="flex-col-center h-screen w-screen gap-40">
+      <div className="flex-col-center gap-20">
+        <div className="flex-col-center gap-8">
+          <div className="text-26 font-bold">페이지를 찾을 수 없습니다 🧐</div>
+          <p className="text-center text-14 font-medium">접근 권한이 없으므로 해당 페이지를 사용하실 수 없습니다.</p>
+        </div>
+        <div className="flex items-center gap-15">
+          <Link href="/">
+            <div className="rounded-md border-1 border-solid border-primary p-8 text-center text-14 font-medium text-primary">
+              아트 톡톡 작품 <br />
+              검색하러 가기
+            </div>
+          </Link>
+          <Link href="/login">
+            <div className="rounded-md border-1 border-solid border-primary p-8 text-center text-14 font-medium text-primary">
+              아트 톡톡 <br />
+              로그인하러 가기
+            </div>
+          </Link>
+        </div>
+        <Image src={logoImg} alt="아트 톡톡 로고" width={167} height={70} />
+      </div>
+      <InfiniteText text="Sorry Nod Found 👻 . this page is gone .  😥 Art Talk - Talk" />
+    </div>
+  );
+}
+
+export default NoAccess;

--- a/src/app/(root-modal)/ArtModal/ArtModal.tsx
+++ b/src/app/(root-modal)/ArtModal/ArtModal.tsx
@@ -7,17 +7,32 @@ import BlackLike from '@/components/Comment/BlackLike';
 import CommentContainer from '@/components/Comment/CommentContainer';
 import RedLike from '@/components/Comment/RedLike';
 import SlideContainer from '@/components/SlideContainer/SlideContainer';
+import useDropDown from '@/hooks/useDropDown';
+import useOnClickOutside from '@/hooks/useOnClickOutside';
 import { useStore } from '@/store';
 import { GetSpecificCardResponseType } from '@/types/cards';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import DOMPurify from 'dompurify';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { MouseEvent, useRef, useEffect, useState } from 'react';
+import ProfileDropDownImage from '../../../../public/assets/icons/KebabDropDown.svg';
 import CommentIcon from '../../../../public/assets/icons/comment.svg';
+import MenuIcon from '../../../../public/assets/icons/menu.svg';
 import Modal from '../_components';
 
 export default function ArtModal() {
-  const clickedArtworkId = useStore((state) => state.clickedArtworkId);
+  const [isLikeClicked, setIsLikeClicked] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const { isOpen: isDropDownOpen, handleDropDownOpen, handleDropDownClose } = useDropDown();
+  useOnClickOutside(containerRef, handleDropDownClose);
+
+  const { clickedArtworkId, userId, showModal, setClickedArtworkId } = useStore((state) => ({
+    clickedArtworkId: state.clickedArtworkId,
+    userId: state.userId,
+    showModal: state.showModal,
+    setClickedArtworkId: state.setClickedArtworkId,
+  }));
 
   const { data: artwork } = useQuery<GetSpecificCardResponseType>({
     queryKey: ['artwork', clickedArtworkId],
@@ -26,7 +41,6 @@ export default function ArtModal() {
   });
 
   const [likeCount, setLikeCount] = useState(artwork?.likeCount || 0);
-  const [isLikeClicked, setIsLikeClicked] = useState(false);
   const [likeId, setLikeId] = useState<number | null>(artwork?.likeId || null);
 
   const queryClient = useQueryClient();
@@ -83,6 +97,27 @@ export default function ArtModal() {
     );
   };
 
+  const handleKebabClick = (e: MouseEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    if (isDropDownOpen) handleDropDownClose();
+    else handleDropDownOpen();
+  };
+
+  const handleModifyClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    if (artwork?.artworkId) {
+      setClickedArtworkId(artwork?.artworkId);
+      showModal('editModal');
+    }
+  };
+
+  const handleDeleteClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    if (artwork?.artworkId) {
+      showModal('askForDelete');
+      setClickedArtworkId(artwork?.artworkId);
+    }
+  };
   // likeId 있을 때 좋아요 색을 빨간 색으로 바꿔준다.
   useEffect(() => {
     if (!likeId) return;
@@ -158,6 +193,37 @@ export default function ArtModal() {
                       : (artwork.commentCount / 1000).toFixed(1) + 'k')}
                 </span>
               </Link>
+              {artwork?.artistId === userId && (
+                <div className="relative" ref={containerRef}>
+                  <div
+                    className="flex-col-center h-48 w-48 cursor-pointer rounded-full shadow-[0px_0px_12px_rgba(0,0,0,0.3)]"
+                    onClick={handleKebabClick}
+                  >
+                    <MenuIcon />
+                  </div>
+                  {isDropDownOpen && (
+                    <div className="absolute -left-100 -top-25">
+                      <div className="rotate-90">
+                        <ProfileDropDownImage />
+                      </div>
+                      <div className="absolute -left-21 top-25 flex h-61 w-105 rounded-sm">
+                        <button
+                          className="w-51 rounded-bl-sm rounded-tl-sm hover:bg-primary-1"
+                          onClick={handleModifyClick}
+                        >
+                          수정
+                        </button>
+                        <button
+                          className="w-52 rounded-br-sm rounded-tr-sm border-l-1 border-solid border-l-gray-4 hover:bg-primary-1"
+                          onClick={handleDeleteClick}
+                        >
+                          삭제
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/app/(root-modal)/AskForDeleteModal/AskForDeleteModal.tsx
+++ b/src/app/(root-modal)/AskForDeleteModal/AskForDeleteModal.tsx
@@ -8,7 +8,8 @@ import { toast } from 'react-toastify';
 import Modal from '../_components';
 
 export default function AskForDeleteModal() {
-  const { clearModal, clickedArtworkId } = useStore((state) => ({
+  const { hideModal, clearModal, clickedArtworkId } = useStore((state) => ({
+    hideModal: state.hideModal,
     clearModal: state.clearModal,
     clickedArtworkId: state.clickedArtworkId,
   }));
@@ -18,6 +19,7 @@ export default function AskForDeleteModal() {
   const deleteMutation = useMutation({
     mutationFn: deleteArtwork,
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['allArtworks'] });
       queryClient.invalidateQueries({ queryKey: ['myArtworks', '전체'] });
       queryClient.invalidateQueries({ queryKey: ['myArtworks', '판매중'] });
     },
@@ -50,7 +52,7 @@ export default function AskForDeleteModal() {
           <Button
             classname="primary-button h-35 w-80 text-black border-primary bg-white hover:bg-primary hover:text-white"
             isLink={false}
-            onClick={clearModal}
+            onClick={() => hideModal('askForDelete')}
           >
             취소
           </Button>

--- a/src/app/(root-modal)/EditUploadModal/EditUploadModal.tsx
+++ b/src/app/(root-modal)/EditUploadModal/EditUploadModal.tsx
@@ -26,13 +26,16 @@ import StatusLabelsGroup from '../UploadModal/_components/StatusLabelsGroup';
 import TextEditor from '../UploadModal/_components/TextEditor';
 import Modal from '../_components';
 import WarningForBigImage from '../WarningForBigImage/WarningForBigImage';
+import { UserType } from '@/types/users';
+import getUser from '@/api/users/getUser';
 
 export default function EditUploadModal() {
-  const { modals, clearModal, showModal, clickedArtworkId } = useStore((state) => ({
+  const { modals, clearModal, showModal, clickedArtworkId, userId } = useStore((state) => ({
     modals: state.modals,
     clearModal: state.clearModal,
     showModal: state.showModal,
     clickedArtworkId: state.clickedArtworkId,
+    userId: state.userId,
   }));
 
   const { data: artwork } = useQuery<GetSpecificCardResponseType>({
@@ -57,6 +60,11 @@ export default function EditUploadModal() {
   const queryClient = useQueryClient();
 
   // handlers
+  const { data: userData } = useQuery<UserType>({
+    queryKey: ['user', userId],
+    queryFn: () => getUser(userId),
+  });
+
   const uploadPutMutation = useMutation({
     mutationFn: (newPost: PutCardRequestType) => putArtwork(newPost),
     onSuccess: () => {
@@ -202,7 +210,7 @@ export default function EditUploadModal() {
 
   return (
     <Modal.Container classname="modalContainer">
-      <Modal.Header />
+      <Modal.Header nickname={userData?.nickname} profileImageUrl={userData?.profileImageUrl} />
       <Modal.Body classname="flex h-full">
         <DragDropContext onDragEnd={onDragEnd}>
           {uploadImageSources?.length ? (
@@ -248,7 +256,7 @@ export default function EditUploadModal() {
         <div className="relative flex h-full w-2/5 flex-col gap-18 p-20">
           <input
             id="title"
-            className="h-39 w-300 p-10 text-14 font-semibold placeholder:text-gray-5"
+            className={`h-39 ${label === 'PUBLIC' ? 'w-full' : 'w-290'} rounded-xs border-1 border-solid border-[#ccc] p-10 text-14 font-semibold placeholder:text-gray-5`}
             value={title}
             type="text"
             spellCheck="false"
@@ -257,7 +265,7 @@ export default function EditUploadModal() {
           />
           <TextEditor value={description} setValue={setDescription} />
           <div className="flex items-center justify-between gap-18">
-            <StatusLabelsGroup setStatusValue={setLabel} />
+            <StatusLabelsGroup setStatusValue={setLabel} statusValue={label} />
             <Button.Modal.Action
               disabled={!title || !description || description === '<p><br></p>' || uploadImageSources?.length === 0}
               wrapperStyle=""

--- a/src/app/(root-modal)/EditUploadModal/EditUploadModal.tsx
+++ b/src/app/(root-modal)/EditUploadModal/EditUploadModal.tsx
@@ -139,8 +139,8 @@ export default function EditUploadModal() {
     for (const id of imageOrderList) {
       if (typeof id !== 'number') {
         showModal('warningForBigImageModal');
-        imageOrderList = [];
-        imageUrlList = [];
+        imageOrderList = [...imageOrder];
+        imageUrlList = [...uploadImageSources];
         e.target.value = '';
         break;
       }

--- a/src/app/(root-modal)/EditUploadModal/EditUploadModal.tsx
+++ b/src/app/(root-modal)/EditUploadModal/EditUploadModal.tsx
@@ -30,9 +30,9 @@ import { UserType } from '@/types/users';
 import getUser from '@/api/users/getUser';
 
 export default function EditUploadModal() {
-  const { modals, clearModal, showModal, clickedArtworkId, userId } = useStore((state) => ({
+  const { modals, hideModal, showModal, clickedArtworkId, userId } = useStore((state) => ({
     modals: state.modals,
-    clearModal: state.clearModal,
+    hideModal: state.hideModal,
     showModal: state.showModal,
     clickedArtworkId: state.clickedArtworkId,
     userId: state.userId,
@@ -68,6 +68,7 @@ export default function EditUploadModal() {
   const uploadPutMutation = useMutation({
     mutationFn: (newPost: PutCardRequestType) => putArtwork(newPost),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['artwork', clickedArtworkId] });
       queryClient.invalidateQueries({ queryKey: ['myArtworks', '전체'] });
       queryClient.invalidateQueries({ queryKey: ['myArtworks', '판매중'] });
     },
@@ -88,14 +89,13 @@ export default function EditUploadModal() {
         } else {
           toast.success('작품 업로드 성공! 🎉');
 
-          clearModal();
+          hideModal(modals[modals.length - 1]);
         }
       },
       onError: (err) => {
         console.log(err);
       },
     });
-    clearModal();
   };
 
   const getImageData = async (file: File) => {

--- a/src/app/(root-modal)/EditUploadModal/EditUploadModal.tsx
+++ b/src/app/(root-modal)/EditUploadModal/EditUploadModal.tsx
@@ -25,10 +25,13 @@ import PreviewImage from '../UploadModal/_components/PreviewImage';
 import StatusLabelsGroup from '../UploadModal/_components/StatusLabelsGroup';
 import TextEditor from '../UploadModal/_components/TextEditor';
 import Modal from '../_components';
+import WarningForBigImage from '../WarningForBigImage/WarningForBigImage';
 
 export default function EditUploadModal() {
-  const { clearModal, clickedArtworkId } = useStore((state) => ({
+  const { modals, clearModal, showModal, clickedArtworkId } = useStore((state) => ({
+    modals: state.modals,
     clearModal: state.clearModal,
+    showModal: state.showModal,
     clickedArtworkId: state.clickedArtworkId,
   }));
 
@@ -48,7 +51,6 @@ export default function EditUploadModal() {
   const [showImage, setShowImage] = useState(false);
   const [selectedImage, setSelectedImage] = useState('');
   const [imageOrder, setImageOrder] = useState<number[] | undefined>(responseImageIds);
-  const [, setCurrentImageData] = useState<ImageArtworkType | undefined>();
 
   //hooks
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -72,9 +74,12 @@ export default function EditUploadModal() {
     uploadPutMutation.mutate(newPost, {
       onSuccess: (res) => {
         if (res?.data === 'fail') {
-          toast.error('작품 수정 실패!');
+          toast.error('작품 업로드 실패!');
+        } else if (res?.data.message === 'The given id must not be null') {
+          toast.error('작품 업로드 실패!');
         } else {
-          toast.success('작품 수정 성공! 🎉');
+          toast.success('작품 업로드 성공! 🎉');
+
           clearModal();
         }
       },
@@ -91,7 +96,6 @@ export default function EditUploadModal() {
 
     try {
       const { imageId, imageUrl } = await postUploadImageFile(formData);
-      setCurrentImageData({ imageId, imageUrl });
       return { imageId, imageUrl };
     } catch (error) {
       console.error('Error occurred while uploading image file:', error);
@@ -122,6 +126,16 @@ export default function EditUploadModal() {
     if (imageUrlList.length > 10) {
       imageUrlList = imageUrlList.slice(0, 10);
       imageOrderList = imageOrderList.slice(0, 10);
+    }
+
+    for (const id of imageOrderList) {
+      if (typeof id !== 'number') {
+        showModal('warningForBigImageModal');
+        imageOrderList = [];
+        imageUrlList = [];
+        e.target.value = '';
+        break;
+      }
     }
 
     setUploadImageSources(imageUrlList);
@@ -274,6 +288,7 @@ export default function EditUploadModal() {
           </>
         )}
       </Modal.Body>
+      {modals[modals.length - 1] === 'warningForBigImageModal' && <WarningForBigImage />}
     </Modal.Container>
   );
 }

--- a/src/app/(root-modal)/UploadModal/UploadModal.tsx
+++ b/src/app/(root-modal)/UploadModal/UploadModal.tsx
@@ -26,6 +26,7 @@ import DeleteAllImageButton from './_components/DeleteAllImageButton';
 import PreviewImage from './_components/PreviewImage';
 import StatusLabelsGroup from './_components/StatusLabelsGroup';
 import TextEditor from './_components/TextEditor';
+import WarningForBigImage from '../WarningForBigImage/WarningForBigImage';
 
 export default function UploadModal() {
   // states
@@ -36,10 +37,11 @@ export default function UploadModal() {
   const [showImage, setShowImage] = useState(false);
   const [selectedImage, setSelectedImage] = useState('');
   const [imageOrder, setImageOrder] = useState<number[]>([]);
-  const [, setCurrentImageData] = useState<ImageArtworkType | undefined>();
 
-  const { clearModal, userId } = useStore((state) => ({
+  const { modals, clearModal, showModal, userId } = useStore((state) => ({
+    modals: state.modals,
     clearModal: state.clearModal,
+    showModal: state.showModal,
     userId: state.userId,
   }));
 
@@ -74,6 +76,8 @@ export default function UploadModal() {
       onSuccess: (res) => {
         if (res?.data === 'fail') {
           toast.error('작품 업로드 실패!');
+        } else if (res?.data.message === 'The given id must not be null') {
+          toast.error('작품 업로드 실패!');
         } else {
           toast.success('작품 업로드 성공! 🎉');
 
@@ -92,7 +96,6 @@ export default function UploadModal() {
 
     try {
       const { imageId, imageUrl } = await postUploadImageFile(formData);
-      setCurrentImageData({ imageId, imageUrl });
       return { imageId, imageUrl };
     } catch (error) {
       console.error('Error occurred while uploading image file:', error);
@@ -110,6 +113,7 @@ export default function UploadModal() {
     for (const file of fileList) {
       try {
         const imageData = await getImageData(file);
+
         imageOrderList.push(imageData.imageId);
         imageUrlList.push(imageData.imageUrl);
       } catch (error) {
@@ -120,6 +124,16 @@ export default function UploadModal() {
     if (imageUrlList.length > 10) {
       imageUrlList = imageUrlList.slice(0, 10);
       imageOrderList = imageOrderList.slice(0, 10);
+    }
+
+    for (const id of imageOrderList) {
+      if (typeof id !== 'number') {
+        showModal('warningForBigImageModal');
+        imageOrderList = [];
+        imageUrlList = [];
+        e.target.value = '';
+        break;
+      }
     }
 
     setUploadImageSources(imageUrlList);
@@ -248,6 +262,7 @@ export default function UploadModal() {
           </>
         )}
       </Modal.Body>
+      {modals[modals.length - 1] === 'warningForBigImageModal' && <WarningForBigImage />}
     </Modal.Container>
   );
 }

--- a/src/app/(root-modal)/UploadModal/UploadModal.tsx
+++ b/src/app/(root-modal)/UploadModal/UploadModal.tsx
@@ -222,7 +222,7 @@ export default function UploadModal() {
         <div className="relative flex h-full w-2/5 flex-col gap-18 p-15">
           <input
             id="title"
-            className="h-39 w-full rounded-[6px] border-1 border-solid border-[#ccc] p-10 text-14 font-semibold placeholder:text-gray-5"
+            className={`h-39 ${label === 'PUBLIC' ? 'w-full' : 'w-290'} rounded-xs border-1 border-solid border-[#ccc] p-10 text-14 font-semibold placeholder:text-gray-5`}
             value={title}
             type="text"
             spellCheck="false"

--- a/src/app/(root-modal)/UploadModal/UploadModal.tsx
+++ b/src/app/(root-modal)/UploadModal/UploadModal.tsx
@@ -129,8 +129,8 @@ export default function UploadModal() {
     for (const id of imageOrderList) {
       if (typeof id !== 'number') {
         showModal('warningForBigImageModal');
-        imageOrderList = [];
-        imageUrlList = [];
+        imageOrderList = [...imageOrder];
+        imageUrlList = [...uploadImageSources];
         e.target.value = '';
         break;
       }

--- a/src/app/(root-modal)/UploadModal/UploadModal.tsx
+++ b/src/app/(root-modal)/UploadModal/UploadModal.tsx
@@ -219,10 +219,10 @@ export default function UploadModal() {
           ref={inputRef}
           onChange={handleUploadImage}
         />
-        <div className="relative flex h-full w-2/5 flex-col gap-18 p-20">
+        <div className="relative flex h-full w-2/5 flex-col gap-18 p-15">
           <input
             id="title"
-            className="h-39 w-300 p-10 text-14 font-semibold placeholder:text-gray-5"
+            className="h-39 w-full rounded-[6px] border-1 border-solid border-[#ccc] p-10 text-14 font-semibold placeholder:text-gray-5"
             value={title}
             type="text"
             spellCheck="false"

--- a/src/app/(root-modal)/UploadModal/_components/StatusLabelsGroup.tsx
+++ b/src/app/(root-modal)/UploadModal/_components/StatusLabelsGroup.tsx
@@ -5,23 +5,24 @@ import '@/styles/tailwind.css';
 import { Dispatch, SetStateAction, useState } from 'react';
 
 enum ButtonCategoryText {
-  'POST' = '게시용',
-  'SALE' = '판매용',
-  'SHARE' = '나눔용',
+  'PUBLIC' = '게시용',
+  'SELLING' = '판매용',
+  'FREE' = '나눔용',
 }
 
 interface Props {
   setStatusValue:
     | Dispatch<SetStateAction<'PUBLIC' | 'SELLING' | 'FREE'>>
     | Dispatch<SetStateAction<'PUBLIC' | 'SELLING' | 'FREE' | undefined>>;
+  statusValue?: 'PUBLIC' | 'SELLING' | 'FREE' | undefined;
 }
 
-function StatusLabelsGroup({ setStatusValue }: Props) {
-  const [content, setContent] = useState('');
+function StatusLabelsGroup({ setStatusValue, statusValue }: Props) {
+  const [content, setContent] = useState(statusValue ? ButtonCategoryText[statusValue] : '');
   const labelTexts: ButtonCategoryText[] = [
-    ButtonCategoryText.POST, // 게시용
-    ButtonCategoryText.SALE, // 판매용
-    ButtonCategoryText.SHARE, // 나눔용
+    ButtonCategoryText.PUBLIC, // 게시용
+    ButtonCategoryText.SELLING, // 판매용
+    ButtonCategoryText.FREE, // 나눔용
   ];
 
   const handleActive = (buttonLabel: string) => {

--- a/src/app/(root-modal)/UploadModal/_components/TextEditor.css
+++ b/src/app/(root-modal)/UploadModal/_components/TextEditor.css
@@ -3,7 +3,7 @@
 }
 
 .ql-toolbar {
-  border-radius: 6px 6px 0 0;
+  border-radius: 8px 8px 0 0;
 }
 
 /* .ql-toolbar.ql-snow {
@@ -12,7 +12,7 @@
 } */
 
 .ql-container.ql-snow {
-  border-radius: 0 0 6px 6px;
+  border-radius: 0 0 8px 8px;
   height: 270px;
 }
 

--- a/src/app/(root-modal)/UploadModal/_components/TextEditor.css
+++ b/src/app/(root-modal)/UploadModal/_components/TextEditor.css
@@ -1,16 +1,31 @@
-.ql-container {
-  max-height: 333px;
+.quill {
+  position: relative;
+}
+
+.ql-toolbar {
+  border-radius: 6px 6px 0 0;
+}
+
+/* .ql-toolbar.ql-snow {
+  position: absolute;
+  top: 270px;
+} */
+
+.ql-container.ql-snow {
+  border-radius: 0 0 6px 6px;
+  height: 270px;
 }
 
 .ql-editor {
   padding: 10px 10px;
-  max-height: 300px;
+  max-height: 250px !important;
   overflow-y: scroll;
   font-size: 14px;
-  line-height: 1.5;
 }
 
 .ql-editor.ql-blank::before {
-  font-style: unset;
-  padding-left: -20px;
+  font-style: unset !important;
+  /* margin-left: -2px !important; */
+  color: #ededed;
+  font-weight: 500;
 }

--- a/src/app/(root-modal)/UploadModal/_components/TextEditor.tsx
+++ b/src/app/(root-modal)/UploadModal/_components/TextEditor.tsx
@@ -4,10 +4,11 @@ import dynamic from 'next/dynamic';
 import { Dispatch, SetStateAction, useMemo } from 'react';
 import './TextEditor.css';
 import 'react-quill/dist/quill.snow.css';
+import TextEditorLoader from './TextEditorLoader';
 
 const QuillNoSSRWrapper = dynamic(() => import('react-quill'), {
   ssr: false,
-  loading: () => <p>Loading ...</p>,
+  loading: () => <TextEditorLoader />,
 });
 
 interface Props {

--- a/src/app/(root-modal)/UploadModal/_components/TextEditor.tsx
+++ b/src/app/(root-modal)/UploadModal/_components/TextEditor.tsx
@@ -3,6 +3,7 @@
 import dynamic from 'next/dynamic';
 import { Dispatch, SetStateAction, useMemo } from 'react';
 import './TextEditor.css';
+import 'react-quill/dist/quill.snow.css';
 
 const QuillNoSSRWrapper = dynamic(() => import('react-quill'), {
   ssr: false,
@@ -19,20 +20,20 @@ function TextEditor({ value, setValue }: Props) {
     () => ({
       toolbar: [
         [{ size: ['small', false, 'large'] }],
-        [{ color: [] }],
+        [{ header: [1, 2, 3, 4, 5, 6, false] }],
+        [{ color: [] }, { background: [] }],
         ['bold', 'underline', 'blockquote'],
-        [{ list: 'ordered' }, { list: 'bullet' }],
       ],
     }),
     [],
   );
 
-  const formats = ['size', 'color', 'bold', 'underline', 'blockquote', 'list', 'bullet'];
+  const formats = ['size', 'header', 'color', 'background', 'bold', 'underline', 'blockquote', 'bullet'];
 
   return (
-    <div className="h-330 w-355">
+    <div className="w-full">
       <QuillNoSSRWrapper
-        theme="bubble"
+        theme="snow"
         modules={modules}
         formats={formats}
         value={value}

--- a/src/app/(root-modal)/UploadModal/_components/TextEditorLoader.tsx
+++ b/src/app/(root-modal)/UploadModal/_components/TextEditorLoader.tsx
@@ -1,7 +1,7 @@
 export default function TextEditorLoader() {
   return (
     <div className="animate-pulse">
-      <div className="h-339 w-full rounded-xs"></div>
+      <div className="h-339 w-full rounded-xs border-1 border-solid border-[#ccc] bg-gray-1"></div>
     </div>
   );
 }

--- a/src/app/(root-modal)/UploadModal/_components/TextEditorLoader.tsx
+++ b/src/app/(root-modal)/UploadModal/_components/TextEditorLoader.tsx
@@ -1,0 +1,7 @@
+export default function TextEditorLoader() {
+  return (
+    <div className="animate-pulse">
+      <div className="h-339 w-full rounded-xs"></div>
+    </div>
+  );
+}

--- a/src/app/(root-modal)/WarningForBigImage/WarningForBigImage.tsx
+++ b/src/app/(root-modal)/WarningForBigImage/WarningForBigImage.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { Button } from '@/components/Button';
+import { useStore } from '@/store';
+import Modal from '../_components';
+
+export default function WarningForBigImage() {
+  const hideModal = useStore((state) => state.hideModal);
+
+  return (
+    <Modal.Container classname="askForSignupContainer">
+      <Modal.Body classname="flex flex-col-center gap-15">
+        <div>파일 용량이 너무 큽니다. 🚫</div>
+        <Button
+          classname="primary-button h-35 w-80 text-white border-primary bg-primary"
+          isLink={false}
+          onClick={() => hideModal('warningForBigImageModal')}
+        >
+          확인
+        </Button>
+      </Modal.Body>
+    </Modal.Container>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,9 +2,8 @@ import { AuthSession } from '@/contexts/AuthSessionProvider';
 import ReactQueryProviders from '@/utils/ReactQueryProvider';
 import type { Metadata } from 'next';
 import { Noto_Sans_KR } from 'next/font/google';
-import '../styles/globals.css';
-import NavBar from '@/components/NavBar/NavBar';
 import { ToastContainer } from 'react-toastify';
+import '../styles/globals.css';
 
 // Noto sans 폰트 적용
 const notoSansKr = Noto_Sans_KR({

--- a/src/components/Card/CardContainer.tsx
+++ b/src/components/Card/CardContainer.tsx
@@ -87,7 +87,7 @@ function CardContainer({ type, categoryType }: Props) {
         {data &&
           data.pages.map((page: ArtWorks) => {
             const cards = page.contents;
-            return cards.map((card) => {
+            return cards?.map((card) => {
               return (
                 <Card
                   key={card.artworkId}

--- a/src/components/Card/CardContainer.tsx
+++ b/src/components/Card/CardContainer.tsx
@@ -109,8 +109,8 @@ function CardContainer({ type, categoryType }: Props) {
           })}
         <div ref={bottom} />
       </div>
+      {modals.includes('editModal') && <EditUploadModal />}
       {modals[modals?.length - 1] === 'artModal' && <ArtModal />}
-      {modals[modals?.length - 1] === 'editModal' && <EditUploadModal />}
       {modals[modals?.length - 1] === 'askForDelete' && <AskForDeleteModal />}
     </>
   );

--- a/src/components/Card/CardContainer.tsx
+++ b/src/components/Card/CardContainer.tsx
@@ -110,7 +110,7 @@ function CardContainer({ type, categoryType }: Props) {
         <div ref={bottom} />
       </div>
       {modals.includes('editModal') && <EditUploadModal />}
-      {modals[modals?.length - 1] === 'artModal' && <ArtModal />}
+      {modals.includes('artModal') && <ArtModal />}
       {modals[modals?.length - 1] === 'askForDelete' && <AskForDeleteModal />}
     </>
   );

--- a/src/components/Card/NoContent.tsx
+++ b/src/components/Card/NoContent.tsx
@@ -14,7 +14,7 @@ function NoContent() {
       <Button isLink={false} classname="primary-button upload-button" onClick={() => showModal('uploadModal')}>
         작품 업로드
       </Button>
-      {modals[modals?.length - 1] === 'uploadModal' && <UploadModal />}
+      {modals.includes('uploadModal') && <UploadModal />}
     </div>
   );
 }

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -24,7 +24,7 @@ function NavBar() {
           <Link href={'/'} className="shrink-0">
             <Image src={logoImg} alt="아트 톡톡 로고" width={85} height={85} />
           </Link>
-          <SearchBar />
+          {firstPathname === 'myAccount' || <SearchBar />}
         </div>
         <NavigatorBox />
       </nav>

--- a/src/components/NavBar/NavigatorBoxButton.tsx
+++ b/src/components/NavBar/NavigatorBoxButton.tsx
@@ -57,7 +57,7 @@ function NavigatorBoxButton({ isLogin }: Props) {
           로그인
         </Button>
       )}
-      {modals[modals?.length - 1] === 'uploadModal' && <UploadModal />}
+      {modals.includes('uploadModal') && <UploadModal />}
       {modals[modals?.length - 1] === 'askForSignup' && <AskForSignupModal />}
     </>
   );

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -14,6 +14,7 @@ import defaultProfileImg from '../../../public/assets/images/logo.png';
 import ProfileFallbackUI from '../FallbackUI/SideBar/ProfileFallbackUI';
 import AddLinkIcon from './AddLinkIcon';
 import LinkIcon from './LinkIcon';
+import DOMPurify from 'dompurify';
 
 interface SideBarProps {
   displayStatus: 'myWork' | 'notMyWork';
@@ -77,7 +78,14 @@ function SideBar({ displayStatus }: SideBarProps) {
             <p className="text-12 text-gray-9">{userInfo?.activityArea + ' / ' + userInfo?.activityField}</p>
           </div>
           <div className="mb-16 mt-16 flex min-h-60 w-192 items-center rounded-sm bg-white p-16">
-            <p className="text-12 text-gray-9">{userInfo?.description}</p>
+            {userInfo?.description && (
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: DOMPurify.sanitize(userInfo?.description.replaceAll(/\n/g, '<br/>')),
+                }}
+                className="text-12 text-gray-9"
+              ></p>
+            )}
           </div>
           <div className="mb-20 flex items-center justify-between gap-20">
             <span className="count">

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -55,7 +55,7 @@ function SideBar({ displayStatus }: SideBarProps) {
   return (
     <div className="fixed left-36 top-110 h-648 w-260 rounded-sm">
       <div className="absolute -top-10 left-1/2 z-first h-120 w-120 -translate-x-1/2 transform rounded-full">
-        <div className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-full border-2 border-solid border-gray-4 bg-white hover:border-primary-3">
+        <div className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-full border-2 border-solid border-gray-4 bg-white">
           <Image
             src={userInfo?.profileImageUrl ? userInfo.profileImageUrl : defaultProfileImg}
             alt="프로필 이미지"

--- a/src/store/zustand.types.ts
+++ b/src/store/zustand.types.ts
@@ -23,7 +23,14 @@ export interface ArtworkState {
   setClickedArtworkId: (id: number) => void;
 }
 
-export type modalType = 'uploadModal' | 'artModal' | 'askForSignup' | 'askForDelete' | 'withdrawalModal' | 'editModal';
+export type modalType =
+  | 'uploadModal'
+  | 'artModal'
+  | 'askForSignup'
+  | 'askForDelete'
+  | 'withdrawalModal'
+  | 'editModal'
+  | 'warningForBigImageModal';
 
 export interface ModalState {
   modals: modalType[];


### PR DESCRIPTION
## 📖 작업 내용

- axios 403, 400 에러 도착 시 NoAccess 페이지로 리다이렉트 구현
- 프로필 수정 페이지 접근 시 로그인 하지 않은 상태면 리다이렉트하도록 적용
  - 프로필 수정 페이지에 검색바 뜨지 않게 구현
- 작품 업로드 시 용량 큰 파일의 경우, 경고 모달이 띄워지도록 구현
- React-quill 디자인 수정 및 작품 업로드 및 수정 디자인 수정
  - React-quill 로딩 시 fallbackUI 적용
- 작품 수정 시 프로필 정보 불러오기 및 게시용, 판매용, 나눔용에 대한 선택된 라벨 적용
- 사이드 바 소개글에 엔터 적용
- 작품 상세 모달에서 작품 수정 및 삭제를 위한 케밥 버튼 구현

## ✅ PR 포인트

- close #138 
- close #137 
- close #136 

## 📸 스크린샷
- 작품 상세 모달 케밥
<img width="1280" alt="image" src="https://github.com/ArtTalkTalk/ArtTalkTalk_frontend/assets/122101706/9d1a15c1-388b-4501-8c32-0a0e3a5ba4f9">

- 작품 업로드 및 수정, React-quill 디자인 변경
<img width="1280" alt="image" src="https://github.com/ArtTalkTalk/ArtTalkTalk_frontend/assets/122101706/88203c05-05f3-456f-aa0a-48bc15cbe38f">
<img width="1280" alt="image" src="https://github.com/ArtTalkTalk/ArtTalkTalk_frontend/assets/122101706/e325bdfb-9a9a-4837-99f2-f15a88a84e21">


- 작품 업로드 및 수정 시 용량 큰 파일에 대한 경고 모달
<img width="1280" alt="image" src="https://github.com/ArtTalkTalk/ArtTalkTalk_frontend/assets/122101706/35afce79-bb6c-4a20-b6c3-285858b80e3f">
